### PR TITLE
Release v12.0

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
+          build-mount-path: '/tmp'
           root-reserve-mb: 512
           swap-size-mb: 1024
           remove-dotnet: 'true'

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -19,10 +19,10 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=ref,prefix="base.",event=pr
-            type=semver,prefix="base.",pattern={{version}}
-            type=semver,prefix="base.",pattern={{major}}.{{minor}}
-            type=raw,prefix="base.",value=edge,enable={{is_default_branch}}
+            type=ref,prefix=base.,event=pr
+            type=semver,prefix=base.,pattern={{version}}
+            type=semver,prefix=base.,pattern={{major}}.{{minor}}
+            type=raw,prefix=base.,value=edge,enable={{is_default_branch}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        type: ["static", "dynamic"]
+        type: [static, dynamic]
     steps:
       - name: Extract Docker metadata
         id: meta
@@ -66,11 +66,11 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=ref,prefix="{{ matrix.type }}.",event=pr
-            type=semver,prefix="{{ matrix.type }}.",pattern={{version}}
-            type=semver,prefix="{{ matrix.type }}.",pattern={{major}}.{{minor}}
+            type=ref,prefix={{ matrix.type }}.,event=pr
+            type=semver,prefix={{ matrix.type }}.,pattern={{version}}
+            type=semver,prefix={{ matrix.type }}.,pattern={{major}}.{{minor}}
             type=raw,value=edge,enable={{is_default_branch}}
-            type=raw,value=latest,enable={{ matrix.type == 'static' }}
+            type=raw,value=latest,enable={{ is_default_branch && matrix.type == 'static' }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -11,6 +11,9 @@ jobs:
     name: Build base image
     runs-on: ubuntu-latest
     steps:
+      - name: Delete unused tools folder
+        run: rm -rf /opt/hostedtoolcache
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          build-mount-path: '/tmp'
+          build-mount-path: '/var/lib/docker/volumes'
           root-reserve-mb: 512
           swap-size-mb: 1024
           remove-dotnet: 'true'

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,8 +1,5 @@
 name: Deploy Docker images
-on:
-  push:
-    branches: ["main", "release-12_v1"]
-    tags: ["v*"]
+on: workflow_dispatch
 
 concurrency: docker
 
@@ -31,7 +28,6 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=ref,prefix=base.,event=branch
             type=ref,prefix=base.,event=pr
             type=semver,prefix=base.,pattern={{version}}
             type=semver,prefix=base.,pattern={{major}}.{{minor}}
@@ -79,7 +75,6 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=ref,prefix=base.,event=branch
             type=ref,prefix={{ matrix.type }}.,event=pr
             type=semver,prefix={{ matrix.type }}.,pattern={{version}}
             type=semver,prefix={{ matrix.type }}.,pattern={{major}}.{{minor}}

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -8,7 +8,7 @@ concurrency: docker
 
 jobs:
   base_image:
-    name: Build Docker image
+    name: Build base image
     runs-on: ubuntu-latest
     steps:
       - name: Extract Docker metadata
@@ -19,6 +19,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
+            type=ref,prefix=base.,event=branch
             type=ref,prefix=base.,event=pr
             type=semver,prefix=base.,pattern={{version}}
             type=semver,prefix=base.,pattern={{major}}.{{minor}}
@@ -38,7 +39,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build base image
+      - name: Build image
         uses: docker/build-push-action@v3
         with:
           file: ./Dockerfile.base
@@ -50,7 +51,7 @@ jobs:
           cache-from: type=gha
 
   vcdeps_images:
-    name: Build Docker image
+    name: Build vc-deps images
     runs-on: ubuntu-latest
     needs: base_image
     strategy:
@@ -66,6 +67,7 @@ jobs:
           flavor: |
             latest=false
           tags: |
+            type=ref,prefix=base.,event=branch
             type=ref,prefix={{ matrix.type }}.,event=pr
             type=semver,prefix={{ matrix.type }}.,pattern={{version}}
             type=semver,prefix={{ matrix.type }}.,pattern={{major}}.{{minor}}
@@ -86,7 +88,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build base image
+      - name: Build image
         uses: docker/build-push-action@v3
         with:
           file: ./Dockerfile.{{ matrix.type }}

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,0 +1,98 @@
+name: Build Docker image
+on:
+  push:
+    branches: ["main", "release-12_v1"]
+    tags: ["v*"]
+
+concurrency: docker
+
+jobs:
+  base_image:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/educelab/ci-docker
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,prefix="base.",event=pr
+            type=semver,prefix="base.",pattern={{version}}
+            type=semver,prefix="base.",pattern={{major}}.{{minor}}
+            type=raw,prefix="base.",value=edge,enable={{is_default_branch}}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build base image
+        uses: docker/build-push-action@v3
+        with:
+          file: ./Dockerfile.base
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=gha,mode=max
+          cache-from: type=gha
+
+  vcdeps_images:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+    needs: base_image
+    strategy:
+      fail-fast: false
+      matrix:
+        type: ["static", "dynamic"]
+    steps:
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/educelab/ci-docker
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,prefix="{{ matrix.type }}.",event=pr
+            type=semver,prefix="{{ matrix.type }}.",pattern={{version}}
+            type=semver,prefix="{{ matrix.type }}.",pattern={{major}}.{{minor}}
+            type=raw,value=edge,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{ matrix.type == 'static' }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build base image
+        uses: docker/build-push-action@v3
+        with:
+          file: ./Dockerfile.{{ matrix.type }}
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-to: type=gha,mode=max
+          cache-from: type=gha

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -11,8 +11,16 @@ jobs:
     name: Build base image
     runs-on: ubuntu-latest
     steps:
-      - name: Delete unused tools folder
-        run: rm -rf /opt/hostedtoolcache
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
 
       - name: Extract Docker metadata
         id: meta

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -1,4 +1,4 @@
-name: Build Docker image
+name: Deploy Docker images
 on:
   push:
     branches: ["main", "release-12_v1"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,6 +1,7 @@
 FROM debian:bookworm-slim
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
-LABEL org.opencontainers.image.description Base system-provided packages 
+LABEL org.opencontainers.image.title ci-docker (base)
+LABEL org.opencontainers.image.description Base system packages 
 LABEL org.opencontainers.image.source https://github.com/educelab/ci-docker
 
 # Install apt sources

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -57,7 +57,7 @@ RUN apt-get install --fix-missing --fix-broken -y \
 
 # Install Qt6
 RUN python3 -m venv venv \
-&& source venv/bin/activate \
+&& . ./venv/bin/activate \
 && python -m pip install aqtinstall \
 && mkdir -p /usr/local/Qt-6.6.1/ \
 && aqt install --outputdir /usr/local/Qt-6.6.1/ linux desktop 6.6.1 gcc_64 \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -49,20 +49,20 @@ RUN apt-get install --fix-missing --fix-broken -y \
     python3-dev \
     python3-pip \
     python3-setuptools \
-    python3-venv \
     zlib1g-dev \
 && ln -s /usr/bin/python3 /usr/bin/python \
 && apt-get -t bookworm-backports install -y cmake \
 && apt-get purge && rm -rf /var/lib/apt/lists/*
 
 # Install Qt6
-RUN python3 -m venv venv \
-&& . ./venv/bin/activate \
-&& python -m pip install aqtinstall \
-&& mkdir -p /usr/local/Qt-6.6.1/ \
-&& aqt install --outputdir /usr/local/Qt-6.6.1/ linux desktop 6.6.1 gcc_64 \
-&& deactivate \
-&& rm -rf venv
+RUN curl -O -L https://download.qt.io/archive/qt/6.6/6.6.1/single/qt-everywhere-src-6.6.1.tar.xz \
+&& tar -xf qt-everywhere-src-6.6.1.tar.xz \
+&& cd qt-everywhere-src-6.6.1/ \
+&& ./configure -opensource -nomake examples -nomake tests -bundled-xcb-xinput -confirm-license \
+&& cmake --build . --parallel \
+&& cmake --install . \
+&& cd ../ \
+&& rm -rf qt-*
 
 # Start an interactive shell
 CMD ["/bin/bash"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -49,20 +49,20 @@ RUN apt-get install --fix-missing --fix-broken -y \
     python3-dev \
     python3-pip \
     python3-setuptools \
+    python3-venv \
     zlib1g-dev \
 && ln -s /usr/bin/python3 /usr/bin/python \
 && apt-get -t bookworm-backports install -y cmake \
 && apt-get purge && rm -rf /var/lib/apt/lists/*
 
 # Install Qt6
-RUN curl -O -L https://download.qt.io/archive/qt/6.6/6.6.1/single/qt-everywhere-src-6.6.1.tar.xz \
-&& tar -xf qt-everywhere-src-6.6.1.tar.xz \
-&& cd qt-everywhere-src-6.6.1/ \
-&& ./configure -opensource -nomake examples -nomake tests -bundled-xcb-xinput -confirm-license \
-&& cmake --build . --parallel \
-&& cmake --install . \
-&& cd ../ \
-&& rm -rf qt-*
+RUN python3 -m venv venv \
+&& source venv/bin/activate \
+&& python -m pip install aqtinstall \
+&& mkdir -p /usr/local/Qt-6.6.1/ \
+&& aqt install --outputdir /usr/local/Qt-6.6.1/ linux desktop 6.6.1 gcc_64 \
+&& deactivate \
+&& rm -rf venv
 
 # Start an interactive shell
 CMD ["/bin/bash"]

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,10 +1,10 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
 LABEL org.opencontainers.image.description Base system-provided packages 
 LABEL org.opencontainers.image.source https://github.com/educelab/ci-docker
 
 # Install apt sources
-RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list \
+RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/backports.list \
 && apt-get clean && apt-get -y update
 RUN apt-get install --fix-missing --fix-broken -y \
     build-essential \
@@ -51,13 +51,13 @@ RUN apt-get install --fix-missing --fix-broken -y \
     python3-setuptools \
     zlib1g-dev \
 && ln -s /usr/bin/python3 /usr/bin/python \
-&& apt-get -t bullseye-backports install -y cmake \
+&& apt-get -t bookworm-backports install -y cmake \
 && apt-get purge && rm -rf /var/lib/apt/lists/*
 
 # Install Qt6
-RUN curl -O -L https://download.qt.io/archive/qt/6.4/6.4.2/single/qt-everywhere-src-6.4.2.tar.xz \
-&& tar -xf qt-everywhere-src-6.4.2.tar.xz \
-&& cd qt-everywhere-src-6.4.2/ \
+RUN curl -O -L https://download.qt.io/archive/qt/6.6/6.6.1/single/qt-everywhere-src-6.6.1.tar.xz \
+&& tar -xf qt-everywhere-src-6.6.1.tar.xz \
+&& cd qt-everywhere-src-6.6.1/ \
 && ./configure -opensource -nomake examples -nomake tests -bundled-xcb-xinput -confirm-license \
 && cmake --build . --parallel \
 && cmake --install . \

--- a/Dockerfile.dynamic
+++ b/Dockerfile.dynamic
@@ -1,5 +1,6 @@
 FROM ghcr.io/educelab/ci-docker:12_v1.base
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
+LABEL org.opencontainers.image.title ci-docker (dynamic)
 LABEL org.opencontainers.image.description Dynamic vc-deps libraries
 LABEL org.opencontainers.image.source https://github.com/educelab/ci-docker
 

--- a/Dockerfile.dynamic
+++ b/Dockerfile.dynamic
@@ -1,4 +1,4 @@
-FROM ghcr.io/educelab/ci-docker:12_v1.base
+FROM ghcr.io/educelab/ci-docker:base.latest
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
 LABEL org.opencontainers.image.title ci-docker (dynamic)
 LABEL org.opencontainers.image.description Dynamic vc-deps libraries

--- a/Dockerfile.dynamic
+++ b/Dockerfile.dynamic
@@ -1,4 +1,4 @@
-FROM ghcr.io/educelab/ci-docker:11_v2.base
+FROM ghcr.io/educelab/ci-docker:12_v1.base
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
 LABEL org.opencontainers.image.description Dynamic vc-deps libraries
 LABEL org.opencontainers.image.source https://github.com/educelab/ci-docker

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM ghcr.io/educelab/ci-docker:12_v1.base
+FROM ghcr.io/educelab/ci-docker:base.latest
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
 LABEL org.opencontainers.image.title ci-docker (static)
 LABEL org.opencontainers.image.description Static vc-deps libraries

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,5 +1,6 @@
 FROM ghcr.io/educelab/ci-docker:12_v1.base
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
+LABEL org.opencontainers.image.title ci-docker (static)
 LABEL org.opencontainers.image.description Static vc-deps libraries
 LABEL org.opencontainers.image.source https://github.com/educelab/ci-docker
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,4 +1,4 @@
-FROM ghcr.io/educelab/ci-docker:11_v2.base
+FROM ghcr.io/educelab/ci-docker:12_v1.base
 MAINTAINER Seth Parker <c.seth.parker@uky.edu>
 LABEL org.opencontainers.image.description Static vc-deps libraries
 LABEL org.opencontainers.image.source https://github.com/educelab/ci-docker

--- a/README.md
+++ b/README.md
@@ -20,5 +20,12 @@ docker buildx create --use
 ```
 
 ## Updating the version
-1. Change `VERSION` in [build.sh](build.sh)
-2. Update the base image version in the `FROM` command for each of the `Dockerfile.[static|dynamic]` files
+Change the version components in [build.sh](build.sh). Values should match the rules 
+for [semantic versioning](https://semver.org/):
+
+```bash
+# build.sh
+VER_MAJOR=12
+VER_MINOR=0
+VER_PATCH=0
+```

--- a/build.sh
+++ b/build.sh
@@ -33,9 +33,9 @@ tags() {
 }
 
 echo ========== Building base image  ==========
-docker buildx build --platform linux/amd64,linux/arm64 --push $(labels) $(tags base) -f Dockerfile.base .
+docker buildx build --platform linux/amd64,linux/arm64 --provenance false --push $(labels) $(tags base) -f Dockerfile.base .
 echo ========== Building dynamic image  ==========
-docker buildx build --platform linux/amd64,linux/arm64 --push $(labels) $(tags dynamic) -f Dockerfile.dynamic .
+docker buildx build --platform linux/amd64,linux/arm64 --provenance false --push $(labels) $(tags dynamic) -f Dockerfile.dynamic .
 echo ========== Building static image  ==========
-docker buildx build --platform linux/amd64,linux/arm64 --push $(labels) $(tags static) -f Dockerfile.static .
+docker buildx build --platform linux/amd64,linux/arm64 --provenance false --push $(labels) $(tags static) -f Dockerfile.static .
 echo ========== Done  ==========

--- a/build.sh
+++ b/build.sh
@@ -7,11 +7,10 @@ timestamp() {
 }
 
 REPO=ghcr.io/educelab/ci-docker
-MAJOR=12
-MINOR=0
-PATCH=0
-SUFFIX=
-VERSION_FULL=${MAJOR}.${MINOR}.${PATCH}${SUFFIX}
+VER_MAJOR=12
+VER_MINOR=0
+VER_PATCH=0
+VER_FULL=${VER_MAJOR}.${VER_MINOR}.${VER_PATCH}
 REV=$(git rev-parse --verify HEAD)
 
 labels() {
@@ -19,15 +18,16 @@ labels() {
     --label org.opencontainers.image.licenses=AGPL-3.0 \
     --label org.opencontainers.image.revision=${REV} \
     --label org.opencontainers.image.url=https://github.com/educelab/ci-docker \
-    --label org.opencontainers.image.version=${VERSION_FULL}
+    --label org.opencontainers.image.version=${VER_FULL}
 }
 
 tags() {
   TYPE=$1
-  TAGS="--tag ${REPO}:${TYPE}.${VERSION_FULL} \
-        --tag ${REPO}:${TYPE}.${MAJOR}.${MINOR}"
+  TAGS="--tag ${REPO}:${TYPE}.${VER_FULL} \
+        --tag ${REPO}:${TYPE}.${VER_MAJOR}.${VER_MINOR} \
+        --tag ${REPO}:${TYPE}.latest"
   if [[ $TYPE == 'static' ]]; then
-    TAGS="${TAGS} --tag ${REPO}:latest --tag ${REPO}:${VERSION_FULL} --tag ${REPO}:${MAJOR}.${MINOR}"
+    TAGS="${TAGS} --tag ${REPO}:latest --tag ${REPO}:${VER_FULL} --tag ${REPO}:${VER_MAJOR}.${VER_MINOR}"
   fi
   echo "${TAGS}"
 }

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 REPO=ghcr.io/educelab/ci-docker
-VERSION=11_v2
+VERSION=12_v1
 
 docker buildx build --platform linux/amd64,linux/arm64 --push -t ${REPO}:${VERSION}.base -f Dockerfile.base . && \
 docker buildx build --platform linux/amd64,linux/arm64 --push -t ${REPO}:${VERSION}.dynamic -f Dockerfile.dynamic . && \

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,41 @@
 #!/bin/bash
 
+set -e
+
+timestamp() {
+    date -u +'%Y-%m-%dT%H:%M:%SZ'
+}
+
 REPO=ghcr.io/educelab/ci-docker
-VERSION=12_v1
+MAJOR=12
+MINOR=0
+PATCH=0
+SUFFIX=
+VERSION_FULL=${MAJOR}.${MINOR}.${PATCH}${SUFFIX}
+REV=$(git rev-parse --verify HEAD)
 
-docker buildx build --platform linux/amd64,linux/arm64 --push -t ${REPO}:${VERSION}.base -f Dockerfile.base . && \
-docker buildx build --platform linux/amd64,linux/arm64 --push -t ${REPO}:${VERSION}.dynamic -f Dockerfile.dynamic . && \
-docker buildx build --platform linux/amd64,linux/arm64 --push -t ${REPO}:latest -t ${REPO}:${VERSION}.static -f Dockerfile.static .
+labels() {
+    echo --label org.opencontainers.image.created=$(timestamp) \
+    --label org.opencontainers.image.licenses=AGPL-3.0 \
+    --label org.opencontainers.image.revision=${REV} \
+    --label org.opencontainers.image.url=https://github.com/educelab/ci-docker \
+    --label org.opencontainers.image.version=${VERSION_FULL}
+}
 
-# Extra tags
-docker buildx build --platform linux/amd64 --push -t ${REPO}:${VERSION}.base.amd64 -f Dockerfile.base . && \
-docker buildx build --platform linux/arm64 --push -t ${REPO}:${VERSION}.base.arm64 -f Dockerfile.base . && \
-docker buildx build --platform linux/amd64 --push -t ${REPO}:${VERSION}.static.amd64 -f Dockerfile.static . && \
-docker buildx build --platform linux/arm64 --push -t ${REPO}:${VERSION}.static.arm64 -f Dockerfile.static . && \
-docker buildx build --platform linux/amd64 --push -t ${REPO}:${VERSION}.dynamic.amd64 -f Dockerfile.dynamic . && \
-docker buildx build --platform linux/arm64 --push -t ${REPO}:${VERSION}.dynamic.arm64 -f Dockerfile.dynamic .
+tags() {
+  TYPE=$1
+  TAGS="--tag ${REPO}:${TYPE}.${VERSION_FULL} \
+        --tag ${REPO}:${TYPE}.${MAJOR}.${MINOR}"
+  if [[ $TYPE == 'static' ]]; then
+    TAGS="${TAGS} --tag ${REPO}:latest --tag ${REPO}:${VERSION_FULL} --tag ${REPO}:${MAJOR}.${MINOR}"
+  fi
+  echo "${TAGS}"
+}
+
+echo ========== Building base image  ==========
+docker buildx build --platform linux/amd64,linux/arm64 --push $(labels) $(tags base) -f Dockerfile.base .
+echo ========== Building dynamic image  ==========
+docker buildx build --platform linux/amd64,linux/arm64 --push $(labels) $(tags dynamic) -f Dockerfile.dynamic .
+echo ========== Building static image  ==========
+docker buildx build --platform linux/amd64,linux/arm64 --push $(labels) $(tags static) -f Dockerfile.static .
+echo ========== Done  ==========


### PR DESCRIPTION
- Updates base image to Debian 12 (Bookworm).
- Update to Qt 6.6.1.
- Update to vc-deps 1.8.1.
- Added a GitHub workflow for building the images, but the builds take too long and timeout, so it's disabled.
- Rework the build script to better match the Docker `build-and-push` GitHub action.
- Switch to semantic versioning. From now own, tags for specific images will be `{base|static|dynamic}.{major}.{minor}.{patch}`. The plain `latest`, `{major}.{minor}.{patch}`, `{major}.{minor}` tags will point to the corresponding `static` image.